### PR TITLE
Configurable Hastebin URL and many improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 ====
 To install, copy the contents of `plugins` directory to `~/.config/terminator/plugins` and restart Terminator.
 
+
 Upload to Hastebin
 ----
-Uploads any selected text to [Hastebin](http://hastebin.com) and opens the url on default browser.
+Adds a right-click context menu item to upload selected text to [Hastebin](http://hastebin.com) and opens the resulting URL in the default browser.
 
+
+### Configuration options
+
+* **`base_url`** *(optional, default: `https://hastebin.com`)* \
+  Base URL for Hastebin, for example `https://hastebin.example.local`. Useful if you run a Hastebin under your own domain or use an internal Hastebin at work.


### PR DESCRIPTION
Well, I originally just meant to add a configurable `base_url`, but ended up making a few other improvements too, which simplified some of the code a bit.

---
```
commit c39da0a519723e0cce72aebfe3d96e997df4368b
Author: Brian Cline <brian.cline@gmail.com>
Date:   Sat Apr 8 22:49:41 2017 -0500

    Configurable Hastebin URL and many improvements
    
    * Add optional base_url config option for custom Hastebin URL
    * Store selected text in memory only when menu item is clicked
    * Log an error if Hastebin returns a status other than 200/201/202
    * Change menu icon from magnifying glass to clipboard
    * Make menu item and error strings translatable
    * Simplify code, clean up unused code, address pep8 issues
```